### PR TITLE
upgraded node to the LTS version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /opt/nodejs
 
 ENV NODE_VERSION v4.2.2
 RUN yum install -y git curl && \
-    curl https://nodejs.org/dist/v4.0.0/node-v4.0.0-linux-x64.tar.gz | tar xz --strip-components=1
+    curl https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}-linux-x64.tar.gz | tar xz --strip-components=1
 ENV PATH=${PATH}:/opt/nodejs/bin
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
 FROM quay.io/ukhomeofficedigital/docker-centos-base
 
+ENV NODE_VERSION v4.2.2
+
 RUN mkdir -p /opt/nodejs /app
 
 WORKDIR /opt/nodejs
 RUN yum install -y curl && \
-    curl https://nodejs.org/dist/v4.0.0/node-v4.0.0-linux-x64.tar.gz | tar xz --strip-components=1
+    curl https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}-linux-x64.tar.gz | tar xz --strip-components=1
 ENV PATH=${PATH}:/opt/nodejs/bin
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM quay.io/ukhomeofficedigital/docker-centos-base
 
-ENV NODE_VERSION v4.2.2
-
 RUN mkdir -p /opt/nodejs /app
 
 WORKDIR /opt/nodejs
+
+ENV NODE_VERSION v4.2.2
 RUN yum install -y curl && \
     curl https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}-linux-x64.tar.gz | tar xz --strip-components=1
 ENV PATH=${PATH}:/opt/nodejs/bin

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ We use [SemVer](http://semver.org/) for the version tags available See the tags 
 
 ## Build With
 
-* Node v4.0.0
+* Node v4.2.2
 
 ## Authors
 


### PR DESCRIPTION
4.2.2 is the latests LTS version.  We could also use version 5 but LTS is probably a better bet for us.
