### PR TITLE
Bring container in line with official image behaviour

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,10 @@ ENV PATH=${PATH}:/opt/nodejs/bin
 WORKDIR /app
 
 ONBUILD RUN yum update -y && yum clean
-ONBUILD COPY . /app/
-ONBUILD RUN rm -rf node_modules && npm install
+ONBUILD COPY package.json /app
+ONBUILD RUN npm install
+ONBUILD COPY . /app
+
 COPY entry-point.sh /entry-point.sh
 ENTRYPOINT ["/entry-point.sh"]
 CMD ["start"]


### PR DESCRIPTION
The offical container builds like this

``` dockerfile
FROM node:0.12.6

RUN mkdir -p /usr/src/app
WORKDIR /usr/src/app

ONBUILD COPY package.json /usr/src/app/
ONBUILD RUN npm install
ONBUILD COPY . /usr/src/app

CMD [ "npm", "start" ]
```

This pull request will bring this container inline with that.

Fixes #11
