### PR TITLE
we shouldn't be running app as root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,19 @@
 FROM quay.io/ukhomeofficedigital/docker-centos-base
 
-RUN mkdir -p /opt/nodejs /app
-
+RUN mkdir -p /opt/nodejs
 WORKDIR /opt/nodejs
 
 ENV NODE_VERSION v4.2.2
 RUN yum install -y git curl && \
     curl https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}-linux-x64.tar.gz | tar xz --strip-components=1
-ENV PATH=${PATH}:/opt/nodejs/bin
-WORKDIR /app
 
-ONBUILD COPY . /app/
+RUN useradd app
+USER app
+
+ENV PATH=${PATH}:/opt/nodejs/bin
+WORKDIR /home/app
+
+ONBUILD COPY . .
 ONBUILD RUN rm -rf node_modules && npm install
 COPY entry-point.sh /entry-point.sh
 ENTRYPOINT ["/entry-point.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,13 +8,13 @@ RUN yum install -y git curl && \
     curl https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}-linux-x64.tar.gz | tar xz --strip-components=1
 
 RUN useradd app
-USER app
-
-ENV PATH=${PATH}:/opt/nodejs/bin
 WORKDIR /home/app
 
 ONBUILD COPY . .
-ONBUILD RUN rm -rf node_modules && npm install
+ONBUILD RUN rm -rf node_modules && npm install && chown -r app:app .
+USER app
+ENV PATH=${PATH}:/opt/nodejs/bin
+
 COPY entry-point.sh /entry-point.sh
 ENTRYPOINT ["/entry-point.sh"]
 CMD ["start"]


### PR DESCRIPTION
Probably best to test this with a couple of downstream repos but works for me.  

Even if we remove the ONBUILD stuff we should still have USER app.  This will mean if downstream wants to install a package they'll need to "USER root" but that action will make it clear they should be doing "USER app" after they've finished doing their priveldged things.
