### PR TITLE
Ad/dont copy from root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,20 @@
 FROM quay.io/ukhomeofficedigital/centos-base
 
-RUN mkdir -p /opt/nodejs /app
-
+RUN mkdir -p /opt/nodejs
 WORKDIR /opt/nodejs
 
 ENV NODE_VERSION v4.2.2
 RUN yum install -y git curl && \
     curl https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}-linux-x64.tar.gz | tar xz --strip-components=1
+
+RUN useradd app
+USER app
+
 ENV PATH=${PATH}:/opt/nodejs/bin
-WORKDIR /app
+WORKDIR /home/app
 
 ONBUILD RUN yum clean all && yum update -y && yum clean all && rpm --rebuilddb
-ONBUILD COPY . /app/
+ONBUILD COPY app .
 ONBUILD RUN rm -rf node_modules && npm install
 COPY entry-point.sh /entry-point.sh
 ENTRYPOINT ["/entry-point.sh"]


### PR DESCRIPTION
Basically, we shouldn't copy . (the root of the workspace) into the docker container.  Doing this would be a good security thing.  But the downside is this means downstream developers will need to create an app folder and stick their code in there.

It's been stated you can achieve the same thing with a .dockerignore, which is partially true, but forgets about all the systems that uses these things polluting the workspace with secrets that will at some point be forgotton to ignore.  

Essentially, this is the same argument as having a public folder for your webapp.
